### PR TITLE
Remove dependency on ipaddr.js

### DIFF
--- a/ipcheck.js
+++ b/ipcheck.js
@@ -1,20 +1,5 @@
 var net = require('net');
 
-function compare(addr1, addr2, mask) {
-  var i = 0;
-
-  while (mask >= 8) {
-    if(addr1[i] !== addr2[i]) return false;
-
-    i++;
-    mask -= 8;
-  }
-
-  var shift = 8 - mask;
-  return (addr1[i] >>> shift) === (addr2[i] >>> shift);
-}
-
-
 var IPCheck = module.exports = function(input) {
   var self = this;
 
@@ -107,14 +92,24 @@ IPCheck.prototype.parseIPv6 = function(ip) {
   }
 };
 
-
 IPCheck.prototype.match = function(cidr) {
   var self = this;
 
   if (!(cidr instanceof IPCheck)) cidr = new IPCheck(cidr);
   if (!self.valid || !cidr.valid) return false;
 
-  return compare(self.address, cidr.address, cidr.mask);
+  var mask = cidr.mask;
+  var i = 0;
+
+  while (mask >= 8) {
+    if (self.address[i] !== cidr.address[i]) return false;
+
+    i++;
+    mask -= 8;
+  }
+
+  var shift = 8 - mask;
+  return (self.address[i] >>> shift) === (cidr.address[i] >>> shift);
 };
 
 

--- a/ipcheck.js
+++ b/ipcheck.js
@@ -7,6 +7,7 @@ var ArrayConstructor = typeof Uint8Array === 'undefined' ?
     for (var i = 0; i < arguments.length; i++) {
       arr[i] = arguments[i];
     }
+
     return arr;
   };
 
@@ -63,7 +64,6 @@ IPCheck.prototype.parse = function() {
   self.mask = self.mask || (self.ipv === 4 ? 32 : 128);
 
   if (self.ipv === 4) {
-    self.parseIPv4(ip);
     // difference between ipv4 and ipv6 masks
     self.mask += 96;
   }
@@ -73,11 +73,18 @@ IPCheck.prototype.parse = function() {
     return;
   }
 
-  self.parseIPv6(ip);
+  if(self.ipv === 4){
+    self.parseIPv4(ip);
+  }else{
+    self.parseIPv6(ip);
+  }
 };
 
 IPCheck.prototype.parseIPv4 = function(ip) {
   var self = this;
+
+  // ipv4 addresses live under ::ffff:0:0
+  self.address[10] = self.address[11] = 0xff;
 
   var octets = ip.split('.');
   for (var i = 0; i < 4; i++) {

--- a/ipcheck.js
+++ b/ipcheck.js
@@ -1,17 +1,5 @@
 var net = require('net');
 
-var ArrayConstructor = typeof Uint8Array === 'undefined' ?
-  Array :
-  function() {
-    var arr = new Uint8Array(arguments.length);
-    for (var i = 0; i < arguments.length; i++) {
-      arr[i] = arguments[i];
-    }
-
-    return arr;
-  };
-
-
 function compare(addr1, addr2, mask) {
   var i = 0;
 
@@ -35,7 +23,6 @@ var IPCheck = module.exports = function(input) {
   }
 
   self.input = input;
-  self.address = ArrayConstructor(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
   self.parse();
 };
 
@@ -72,6 +59,8 @@ IPCheck.prototype.parse = function() {
     self.valid = false;
     return;
   }
+
+  self.address = [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ];
 
   if(self.ipv === 4){
     self.parseIPv4(ip);

--- a/ipcheck.js
+++ b/ipcheck.js
@@ -48,7 +48,7 @@ IPCheck.prototype.parse = function() {
   if (!self.valid) return;
 
   // default mask = 32 for ipv4 and 128 for ipv6
-  self.mask = self.mask || (self.ipv === 4 ? 32 : 128);
+  if (self.mask === null) self.mask = self.ipv === 4 ? 32 : 128;
 
   if (self.ipv === 4) {
     // difference between ipv4 and ipv6 masks
@@ -112,7 +112,7 @@ IPCheck.prototype.match = function(cidr) {
   var self = this;
 
   if (!(cidr instanceof IPCheck)) cidr = new IPCheck(cidr);
-  if (!self.valid || !cidr.valid || !cidr.mask) return false;
+  if (!self.valid || !cidr.valid) return false;
 
   return compare(self.address, cidr.address, cidr.mask);
 };

--- a/ipcheck.js
+++ b/ipcheck.js
@@ -1,5 +1,29 @@
 var net = require('net');
-var ipaddr = require('ipaddr.js');
+
+var ArrayConstructor = typeof Uint8Array === 'undefined' ?
+  Array :
+  function() {
+    var arr = new Uint8Array(arguments.length);
+    for(var i = 0; i < arguments.length; i++) {
+      arr[i] = arguments[i];
+    }
+    return arr;
+  };
+
+
+function compare(addr1, addr2, mask){
+  var i = 0;
+
+  while(mask >= 8){
+    if(addr1[i] !== addr2[i]) return false;
+    i++;
+    mask -= 8;
+  }
+
+  var shift = 8 - mask;
+  return (addr1[i] >>> shift) === (addr2[i] >>> shift);
+}
+
 
 var IPCheck = module.exports = function(input) {
   var self = this;
@@ -9,6 +33,7 @@ var IPCheck = module.exports = function(input) {
   }
 
   self.input = input;
+  self.address = ArrayConstructor(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
   self.parse();
 };
 
@@ -17,16 +42,18 @@ IPCheck.prototype.parse = function() {
 
   if (!self.input || typeof self.input !== 'string') return self.valid = false;
 
+  var ip;
+
   var pos = self.input.lastIndexOf('/');
   if (pos !== -1) {
-    self.ip = self.input.substring(0, pos);
+    ip = self.input.substring(0, pos);
     self.mask = +self.input.substring(pos + 1);
   } else {
-    self.ip = self.input;
+    ip = self.input;
     self.mask = null;
   }
 
-  self.ipv = net.isIP(self.ip);
+  self.ipv = net.isIP(ip);
   self.valid = !!self.ipv && !isNaN(self.mask);
 
   if (!self.valid) return;
@@ -35,14 +62,54 @@ IPCheck.prototype.parse = function() {
   self.mask = self.mask || (self.ipv === 4 ? 32 : 128);
 
   if (self.ipv === 4) {
-    self.ip = '::ffff:' + self.ip;
+    self.parseIPv4(ip);
     // difference between ipv4 and ipv6 masks
     self.mask += 96;
   }
 
-  self.parsed = ipaddr.IPv6.parse(self.ip);
+  if(self.mask < 0 || self.mask > 128){
+    self.valid = false;
+    return;
+  }
 
+  self.parseIPv6(ip);
 };
+
+IPCheck.prototype.parseIPv4 = function(ip) {
+  var self = this;
+
+  var octets = ip.split('.');
+  for (var i = 0; i < 4; i++) {
+    self.address[i + 12] = parseInt(octets[i], 10);
+  }
+};
+
+
+var V6_TRANSITIONAL = /:(\d+\.\d+\.\d+\.\d+)$/;
+
+IPCheck.prototype.parseIPv6 = function(ip) {
+  var self = this;
+
+  var transitionalMatch = V6_TRANSITIONAL.exec(ip);
+  if(transitionalMatch){
+    self.parseIPv4(transitionalMatch[1]);
+    return;
+  }
+
+  var bits = ip.split(':');
+  if(bits.length < 8){
+    ip = ip.replace('::', Array(11 - bits.length).join(':'));
+    bits = ip.split(':');
+  }
+
+  var j = 0;
+  for (var i = 0; i < bits.length; i += 1) {
+    var x = bits[i] ? parseInt(bits[i], 16) : 0;
+    self.address[j++] = x >> 8;
+    self.address[j++] = x & 0xff;
+  }
+};
+
 
 IPCheck.prototype.match = function(cidr) {
   var self = this;
@@ -50,7 +117,7 @@ IPCheck.prototype.match = function(cidr) {
   if (!(cidr instanceof IPCheck)) cidr = new IPCheck(cidr);
   if (!self.valid || !cidr.valid || !cidr.mask) return false;
 
-  return self.parsed.match(cidr.parsed, cidr.mask);
+  return compare(self.address, cidr.address, cidr.mask);
 };
 
 

--- a/ipcheck.js
+++ b/ipcheck.js
@@ -4,18 +4,19 @@ var ArrayConstructor = typeof Uint8Array === 'undefined' ?
   Array :
   function() {
     var arr = new Uint8Array(arguments.length);
-    for(var i = 0; i < arguments.length; i++) {
+    for (var i = 0; i < arguments.length; i++) {
       arr[i] = arguments[i];
     }
     return arr;
   };
 
 
-function compare(addr1, addr2, mask){
+function compare(addr1, addr2, mask) {
   var i = 0;
 
-  while(mask >= 8){
+  while (mask >= 8) {
     if(addr1[i] !== addr2[i]) return false;
+
     i++;
     mask -= 8;
   }
@@ -28,7 +29,7 @@ function compare(addr1, addr2, mask){
 var IPCheck = module.exports = function(input) {
   var self = this;
 
-  if(!(self instanceof IPCheck)){
+  if (!(self instanceof IPCheck)) {
     return new IPCheck(input);
   }
 
@@ -67,7 +68,7 @@ IPCheck.prototype.parse = function() {
     self.mask += 96;
   }
 
-  if(self.mask < 0 || self.mask > 128){
+  if (self.mask < 0 || self.mask > 128) {
     self.valid = false;
     return;
   }
@@ -97,7 +98,7 @@ IPCheck.prototype.parseIPv6 = function(ip) {
   }
 
   var bits = ip.split(':');
-  if(bits.length < 8){
+  if (bits.length < 8) {
     ip = ip.replace('::', Array(11 - bits.length).join(':'));
     bits = ip.split(':');
   }

--- a/package.json
+++ b/package.json
@@ -23,9 +23,6 @@
     "url": "https://github.com/gosquared/ipcheck/issues"
   },
   "homepage": "https://github.com/gosquared/ipcheck",
-  "dependencies": {
-    "ipaddr.js": "^1.0.1"
-  },
   "devDependencies": {
     "benchmark": "^1.0.0",
     "ip-address": "^4.0.0",

--- a/test/test.js
+++ b/test/test.js
@@ -36,6 +36,26 @@ describe('IPCheck', function() {
       assert.strictEqual(IPCheck('FE80:0000:0000:0000:0202:B3FF:FE1E:8329').address.length, 16);
     });
 
+    it('should correctly parse addresses', function(){
+
+      function check(str, expected) {
+        var ip = IPCheck(str);
+
+        assert.strictEqual([].join.call(ip.address, ' '), expected.join(' '));
+      }
+
+      check('::', [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]);
+      check('::1', [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 ]);
+      check('0:ffff::', [ 0, 0, 0xff, 0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]);
+      check('ffff::ffff', [ 0xff, 0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff ]);
+      check('1234:5678:9abc:def0:0fed:cba9:8765:4321', [ 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x0f, 0xed, 0xcb, 0xa9, 0x87, 0x65, 0x43, 0x21 ]);
+
+      check('0.0.0.0', [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 0, 0, 0, 0 ]);
+      check('123.234.123.234', [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 123, 234, 123, 234 ]);
+
+      check('::ffff:1.2.3.4', [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 1, 2, 3, 4 ]);
+    });
+
     it('should parse CIDR notation', function() {
       assert.strictEqual(IPCheck('192.168.0.0/32').mask, 32 + 96);
       assert.strictEqual(IPCheck('FE80:0000:0000:0000:0202:B3FF:FE1E:8329/110').mask, 110);

--- a/test/test.js
+++ b/test/test.js
@@ -39,9 +39,7 @@ describe('IPCheck', function() {
     it('should correctly parse addresses', function(){
 
       function check(str, expected) {
-        var ip = IPCheck(str);
-
-        assert.strictEqual([].join.call(ip.address, ' '), expected.join(' '));
+        assert.deepEqual(IPCheck(str).address, expected);
       }
 
       check('::', [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]);

--- a/test/test.js
+++ b/test/test.js
@@ -63,6 +63,11 @@ describe('IPCheck', function() {
       assert.strictEqual(IPCheck('192.168.0.0').mask, 32 + 96);
       assert.strictEqual(IPCheck('FE80:0000:0000:0000:0202:B3FF:FE1E:8329').mask, 128);
     });
+
+    it('shouldn\'t allow non-numeric masks', function() {
+      assert.strictEqual(IPCheck('192.168.0.0/x').valid, false);
+      assert.strictEqual(IPCheck('::1/true').valid, false);
+    });
   });
 
   describe('#match()', function() {
@@ -70,6 +75,8 @@ describe('IPCheck', function() {
       assert.strictEqual(IPCheck('82.5.44.120').match(IPCheck('82.5.44.120/32')), true);
       assert.strictEqual(IPCheck('82.5.44.0').match(IPCheck('82.5.44.120/24')), true);
       assert.strictEqual(IPCheck('82.5.44.255').match(IPCheck('82.5.44.120/24')), true);
+      assert.strictEqual(IPCheck('192.168.0.1').match(IPCheck('0.0.0.0/0')), true);
+      assert.strictEqual(IPCheck('1234:5678:9abc:def0:0fed:cba9:8765:4321').match(IPCheck('0::0/0')), true);
     });
 
     it('shouldn\'t validate an IP outside a CIDR block', function() {
@@ -93,4 +100,4 @@ describe('IPCheck', function() {
     });
 
   });
-})
+});

--- a/test/test.js
+++ b/test/test.js
@@ -32,8 +32,8 @@ describe('IPCheck', function() {
     });
 
     it('should treat everything as IPv6 in ipaddr.js', function() {
-      assert.equal(IPCheck('192.168.0.0').parsed.kind(), 'ipv6');
-      assert.equal(IPCheck('FE80:0000:0000:0000:0202:B3FF:FE1E:8329').parsed.kind(), 'ipv6');
+      assert.strictEqual(IPCheck('192.168.0.0').address.length, 16);
+      assert.strictEqual(IPCheck('FE80:0000:0000:0000:0202:B3FF:FE1E:8329').address.length, 16);
     });
 
     it('should parse CIDR notation', function() {


### PR DESCRIPTION
Parses addresses directly into an array (typed `Uint8Array` if available for speeeeeeed).

I'd like to add a couple more tests to make sure parsing is absolutely correct and wonderful, but if `net.isIP` says the address is valid then I think this should just work fine.

I'm also trying to figure out if there's any way to use the `uv_inet_pton` that `net.isIP` uses internally (in iojs at least) because that does all the parsing work anyway so it's silly to duplicate the work. Don't know whether that's possible though.
